### PR TITLE
Allow discarding increment/decrement return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ work-around:
 
 ## nodiscard
 
-When compiling with C++17 or higher, all generated methods are marked `[[nodiscard]]`.
+When compiling with C++17 or higher, all generated methods except increment / decrement are marked `[[nodiscard]]`.
 For compilers that do not support `[[nodiscard]]` or when it is causing trouble,
 you can disable it defining `TAO_OPERATORS_NODISCARD`:
 

--- a/include/tao/operators.hpp
+++ b/include/tao/operators.hpp
@@ -610,7 +610,7 @@ namespace tao
       template< typename T >
       class TAO_OPERATORS_BROKEN_EBO incrementable
       {
-         TAO_OPERATORS_NODISCARD friend T operator++( T& arg, int /*unused*/ ) noexcept( noexcept( T( arg ), ++arg, T( std::declval< T >() ) ) )  // NOLINT
+         friend T operator++( T& arg, int /*unused*/ ) noexcept( noexcept( T( arg ), ++arg, T( std::declval< T >() ) ) )  // NOLINT
          {
             const T nrv( arg );
             ++arg;
@@ -621,7 +621,7 @@ namespace tao
       template< typename T >
       class TAO_OPERATORS_BROKEN_EBO decrementable
       {
-         TAO_OPERATORS_NODISCARD friend T operator--( T& arg, int /*unused*/ ) noexcept( noexcept( T( arg ), --arg, T( std::declval< T >() ) ) )  // NOLINT
+         friend T operator--( T& arg, int /*unused*/ ) noexcept( noexcept( T( arg ), --arg, T( std::declval< T >() ) ) )  // NOLINT
          {
             const T nrv( arg );
             --arg;


### PR DESCRIPTION
Hello.

While I agree with the values of `[[nodiscard]]` attribute in general, applying it to increments rather bothers me than being insightful.  For instance I hate being warned by the following reproduction code:

```c++
#include "tao/operators.hpp"

class foo : public tao::operators::incrementable<foo> {
  private:
    int i;

  public:
    foo &operator++() noexcept
    {
        i++;
        return *this;
    }
    bool operator!=(const foo &f [[maybe_unused]]) const &noexcept
    {
        return /* fake */ false;
    }
};

int
main()
{
    for (foo i; i != foo(); i++) {
        // ...
    }
}
```

Above `for` loop warns like this:

```
% clang++-8 -std=c++2a tmp.cpp
tmp.cpp:22:30: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
    for (foo i; i != foo(); i++) {
                             ^~
1 warning generated.
```

Can you consider relaxing the restriction?